### PR TITLE
[ISSUE #68]Change from `pub fn` to `pub const fn` for `from_static_str` method

### DIFF
--- a/src/cheetah_string.rs
+++ b/src/cheetah_string.rs
@@ -227,7 +227,7 @@ impl CheetahString {
     }
 
     #[inline]
-    pub fn from_static_str(s: &'static str) -> Self {
+    pub const fn from_static_str(s: &'static str) -> Self {
         CheetahString {
             inner: InnerString::StaticStr(s),
         }


### PR DESCRIPTION
close #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * from_static_str is now const, allowing creation of CheetahString from static strings in const contexts (e.g., consts, statics, and match patterns). This enables compile-time initialization and can reduce runtime overhead.
  * Existing code remains fully compatible; this change broadens where the API can be used without altering behavior at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->