### PR TITLE
[ISSUE #76]✨Add query and transformation methods for CheetahString, including starts_with, ends_with, contains, find, rfind, trim, split, and more

### DIFF
--- a/src/cheetah_string.rs
+++ b/src/cheetah_string.rs
@@ -441,6 +441,277 @@ impl CheetahString {
             InnerString::Bytes(b) => b.is_empty(),
         }
     }
+
+    // Query methods - delegate to &str
+
+    /// Returns `true` if the string starts with the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.starts_with("hello"));
+    /// assert!(!s.starts_with("world"));
+    /// ```
+    #[inline]
+    pub fn starts_with<P: AsRef<str>>(&self, pat: P) -> bool {
+        self.as_str().starts_with(pat.as_ref())
+    }
+
+    /// Returns `true` if the string ends with the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.ends_with("world"));
+    /// assert!(!s.ends_with("hello"));
+    /// ```
+    #[inline]
+    pub fn ends_with<P: AsRef<str>>(&self, pat: P) -> bool {
+        self.as_str().ends_with(pat.as_ref())
+    }
+
+    /// Returns `true` if the string contains the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.contains("llo"));
+    /// assert!(!s.contains("xyz"));
+    /// ```
+    #[inline]
+    pub fn contains<P: AsRef<str>>(&self, pat: P) -> bool {
+        self.as_str().contains(pat.as_ref())
+    }
+
+    /// Returns the byte index of the first occurrence of the pattern, or `None` if not found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert_eq!(s.find("world"), Some(6));
+    /// assert_eq!(s.find("xyz"), None);
+    /// ```
+    #[inline]
+    pub fn find<P: AsRef<str>>(&self, pat: P) -> Option<usize> {
+        self.as_str().find(pat.as_ref())
+    }
+
+    /// Returns the byte index of the last occurrence of the pattern, or `None` if not found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello hello");
+    /// assert_eq!(s.rfind("hello"), Some(6));
+    /// ```
+    #[inline]
+    pub fn rfind<P: AsRef<str>>(&self, pat: P) -> Option<usize> {
+        self.as_str().rfind(pat.as_ref())
+    }
+
+    /// Returns a string slice with leading and trailing whitespace removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("  hello  ");
+    /// assert_eq!(s.trim(), "hello");
+    /// ```
+    #[inline]
+    pub fn trim(&self) -> &str {
+        self.as_str().trim()
+    }
+
+    /// Returns a string slice with leading whitespace removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("  hello");
+    /// assert_eq!(s.trim_start(), "hello");
+    /// ```
+    #[inline]
+    pub fn trim_start(&self) -> &str {
+        self.as_str().trim_start()
+    }
+
+    /// Returns a string slice with trailing whitespace removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello  ");
+    /// assert_eq!(s.trim_end(), "hello");
+    /// ```
+    #[inline]
+    pub fn trim_end(&self) -> &str {
+        self.as_str().trim_end()
+    }
+
+    /// Splits the string by the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("a,b,c");
+    /// let parts: Vec<&str> = s.split(",").collect();
+    /// assert_eq!(parts, vec!["a", "b", "c"]);
+    /// ```
+    #[inline]
+    pub fn split<'a>(&'a self, pat: &'a str) -> impl Iterator<Item = &'a str> {
+        self.as_str().split(pat)
+    }
+
+    /// Returns an iterator over the lines of the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("line1\nline2\nline3");
+    /// let lines: Vec<&str> = s.lines().collect();
+    /// assert_eq!(lines, vec!["line1", "line2", "line3"]);
+    /// ```
+    #[inline]
+    pub fn lines(&self) -> impl Iterator<Item = &str> {
+        self.as_str().lines()
+    }
+
+    /// Returns an iterator over the characters of the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello");
+    /// let chars: Vec<char> = s.chars().collect();
+    /// assert_eq!(chars, vec!['h', 'e', 'l', 'l', 'o']);
+    /// ```
+    #[inline]
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
+        self.as_str().chars()
+    }
+
+    // Transformation methods - create new CheetahString
+
+    /// Returns a new `CheetahString` with all characters converted to uppercase.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello");
+    /// assert_eq!(s.to_uppercase(), "HELLO");
+    /// ```
+    #[inline]
+    pub fn to_uppercase(&self) -> CheetahString {
+        CheetahString::from_string(self.as_str().to_uppercase())
+    }
+
+    /// Returns a new `CheetahString` with all characters converted to lowercase.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("HELLO");
+    /// assert_eq!(s.to_lowercase(), "hello");
+    /// ```
+    #[inline]
+    pub fn to_lowercase(&self) -> CheetahString {
+        CheetahString::from_string(self.as_str().to_lowercase())
+    }
+
+    /// Replaces all occurrences of a pattern with another string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert_eq!(s.replace("world", "rust"), "hello rust");
+    /// ```
+    #[inline]
+    pub fn replace<P: AsRef<str>>(&self, from: P, to: &str) -> CheetahString {
+        CheetahString::from_string(self.as_str().replace(from.as_ref(), to))
+    }
+
+    /// Returns a new `CheetahString` with the specified range replaced.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert_eq!(s.replacen("l", "L", 1), "heLlo world");
+    /// ```
+    #[inline]
+    pub fn replacen<P: AsRef<str>>(&self, from: P, to: &str, count: usize) -> CheetahString {
+        CheetahString::from_string(self.as_str().replacen(from.as_ref(), to, count))
+    }
+
+    /// Returns a substring as a new `CheetahString`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the indices are not on valid UTF-8 character boundaries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert_eq!(s.substring(0, 5), "hello");
+    /// assert_eq!(s.substring(6, 11), "world");
+    /// ```
+    #[inline]
+    pub fn substring(&self, start: usize, end: usize) -> CheetahString {
+        CheetahString::from_slice(&self.as_str()[start..end])
+    }
+
+    /// Repeats the string `n` times.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("abc");
+    /// assert_eq!(s.repeat(3), "abcabcabc");
+    /// ```
+    #[inline]
+    pub fn repeat(&self, n: usize) -> CheetahString {
+        CheetahString::from_string(self.as_str().repeat(n))
+    }
 }
 
 impl PartialEq for CheetahString {
@@ -540,6 +811,121 @@ impl Borrow<str> for CheetahString {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+// Add trait implementations for string concatenation
+
+impl std::ops::Add<&str> for CheetahString {
+    type Output = CheetahString;
+
+    /// Concatenates a `CheetahString` with a string slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("Hello");
+    /// let result = s + " World";
+    /// assert_eq!(result, "Hello World");
+    /// ```
+    #[inline]
+    fn add(self, rhs: &str) -> Self::Output {
+        let mut result = String::with_capacity(self.len() + rhs.len());
+        result.push_str(self.as_str());
+        result.push_str(rhs);
+        CheetahString::from_string(result)
+    }
+}
+
+impl std::ops::Add<&CheetahString> for CheetahString {
+    type Output = CheetahString;
+
+    /// Concatenates two `CheetahString` values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s1 = CheetahString::from("Hello");
+    /// let s2 = CheetahString::from(" World");
+    /// let result = s1 + &s2;
+    /// assert_eq!(result, "Hello World");
+    /// ```
+    #[inline]
+    fn add(self, rhs: &CheetahString) -> Self::Output {
+        let mut result = String::with_capacity(self.len() + rhs.len());
+        result.push_str(self.as_str());
+        result.push_str(rhs.as_str());
+        CheetahString::from_string(result)
+    }
+}
+
+impl std::ops::Add<String> for CheetahString {
+    type Output = CheetahString;
+
+    /// Concatenates a `CheetahString` with a `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("Hello");
+    /// let result = s + String::from(" World");
+    /// assert_eq!(result, "Hello World");
+    /// ```
+    #[inline]
+    fn add(self, rhs: String) -> Self::Output {
+        let mut result = String::with_capacity(self.len() + rhs.len());
+        result.push_str(self.as_str());
+        result.push_str(&rhs);
+        CheetahString::from_string(result)
+    }
+}
+
+impl std::ops::AddAssign<&str> for CheetahString {
+    /// Appends a string slice to a `CheetahString`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let mut s = CheetahString::from("Hello");
+    /// s += " World";
+    /// assert_eq!(s, "Hello World");
+    /// ```
+    #[inline]
+    fn add_assign(&mut self, rhs: &str) {
+        let mut result = String::with_capacity(self.len() + rhs.len());
+        result.push_str(self.as_str());
+        result.push_str(rhs);
+        *self = CheetahString::from_string(result);
+    }
+}
+
+impl std::ops::AddAssign<&CheetahString> for CheetahString {
+    /// Appends a `CheetahString` to another `CheetahString`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let mut s1 = CheetahString::from("Hello");
+    /// let s2 = CheetahString::from(" World");
+    /// s1 += &s2;
+    /// assert_eq!(s1, "Hello World");
+    /// ```
+    #[inline]
+    fn add_assign(&mut self, rhs: &CheetahString) {
+        let mut result = String::with_capacity(self.len() + rhs.len());
+        result.push_str(self.as_str());
+        result.push_str(rhs.as_str());
+        *self = CheetahString::from_string(result);
     }
 }
 

--- a/tests/api_extensions.rs
+++ b/tests/api_extensions.rs
@@ -1,0 +1,326 @@
+use cheetah_string::CheetahString;
+
+// Query methods tests
+
+#[test]
+fn test_starts_with() {
+    let s = CheetahString::from("hello world");
+    assert!(s.starts_with("hello"));
+    assert!(s.starts_with(""));
+    assert!(!s.starts_with("world"));
+    assert!(!s.starts_with("Hello"));
+}
+
+#[test]
+fn test_ends_with() {
+    let s = CheetahString::from("hello world");
+    assert!(s.ends_with("world"));
+    assert!(s.ends_with(""));
+    assert!(!s.ends_with("hello"));
+    assert!(!s.ends_with("World"));
+}
+
+#[test]
+fn test_contains() {
+    let s = CheetahString::from("hello world");
+    assert!(s.contains("llo"));
+    assert!(s.contains("o w"));
+    assert!(s.contains(""));
+    assert!(!s.contains("xyz"));
+    assert!(!s.contains("Hello"));
+}
+
+#[test]
+fn test_find() {
+    let s = CheetahString::from("hello world");
+    assert_eq!(s.find("world"), Some(6));
+    assert_eq!(s.find("hello"), Some(0));
+    assert_eq!(s.find("o"), Some(4));
+    assert_eq!(s.find("xyz"), None);
+    assert_eq!(s.find(""), Some(0));
+}
+
+#[test]
+fn test_rfind() {
+    let s = CheetahString::from("hello hello");
+    assert_eq!(s.rfind("hello"), Some(6));
+    assert_eq!(s.rfind("l"), Some(9));
+    assert_eq!(s.rfind("xyz"), None);
+}
+
+#[test]
+fn test_trim() {
+    let s = CheetahString::from("  hello world  ");
+    assert_eq!(s.trim(), "hello world");
+
+    let s2 = CheetahString::from("hello");
+    assert_eq!(s2.trim(), "hello");
+
+    let s3 = CheetahString::from("   ");
+    assert_eq!(s3.trim(), "");
+}
+
+#[test]
+fn test_trim_start() {
+    let s = CheetahString::from("  hello  ");
+    assert_eq!(s.trim_start(), "hello  ");
+
+    let s2 = CheetahString::from("hello");
+    assert_eq!(s2.trim_start(), "hello");
+}
+
+#[test]
+fn test_trim_end() {
+    let s = CheetahString::from("  hello  ");
+    assert_eq!(s.trim_end(), "  hello");
+
+    let s2 = CheetahString::from("hello");
+    assert_eq!(s2.trim_end(), "hello");
+}
+
+#[test]
+fn test_split() {
+    let s = CheetahString::from("a,b,c");
+    let parts: Vec<&str> = s.split(",").collect();
+    assert_eq!(parts, vec!["a", "b", "c"]);
+
+    let s2 = CheetahString::from("one");
+    let parts2: Vec<&str> = s2.split(",").collect();
+    assert_eq!(parts2, vec!["one"]);
+
+    let s3 = CheetahString::from("");
+    let parts3: Vec<&str> = s3.split(",").collect();
+    assert_eq!(parts3, vec![""]);
+}
+
+#[test]
+fn test_lines() {
+    let s = CheetahString::from("line1\nline2\nline3");
+    let lines: Vec<&str> = s.lines().collect();
+    assert_eq!(lines, vec!["line1", "line2", "line3"]);
+
+    let s2 = CheetahString::from("single line");
+    let lines2: Vec<&str> = s2.lines().collect();
+    assert_eq!(lines2, vec!["single line"]);
+
+    let s3 = CheetahString::from("");
+    let lines3: Vec<&str> = s3.lines().collect();
+    assert_eq!(lines3, Vec::<&str>::new());
+}
+
+#[test]
+fn test_chars() {
+    let s = CheetahString::from("hello");
+    let chars: Vec<char> = s.chars().collect();
+    assert_eq!(chars, vec!['h', 'e', 'l', 'l', 'o']);
+
+    let s2 = CheetahString::from("你好");
+    let chars2: Vec<char> = s2.chars().collect();
+    assert_eq!(chars2, vec!['你', '好']);
+}
+
+// Transformation methods tests
+
+#[test]
+fn test_to_uppercase() {
+    let s = CheetahString::from("hello");
+    assert_eq!(s.to_uppercase(), "HELLO");
+
+    let s2 = CheetahString::from("Hello World");
+    assert_eq!(s2.to_uppercase(), "HELLO WORLD");
+
+    let s3 = CheetahString::from("");
+    assert_eq!(s3.to_uppercase(), "");
+}
+
+#[test]
+fn test_to_lowercase() {
+    let s = CheetahString::from("HELLO");
+    assert_eq!(s.to_lowercase(), "hello");
+
+    let s2 = CheetahString::from("Hello World");
+    assert_eq!(s2.to_lowercase(), "hello world");
+
+    let s3 = CheetahString::from("");
+    assert_eq!(s3.to_lowercase(), "");
+}
+
+#[test]
+fn test_replace() {
+    let s = CheetahString::from("hello world");
+    assert_eq!(s.replace("world", "rust"), "hello rust");
+    assert_eq!(s.replace("l", "L"), "heLLo worLd");
+    assert_eq!(s.replace("xyz", "abc"), "hello world");
+    assert_eq!(s.replace("", "x"), "xhxexlxlxox xwxoxrxlxdx");
+}
+
+#[test]
+fn test_replacen() {
+    let s = CheetahString::from("hello world");
+    assert_eq!(s.replacen("l", "L", 1), "heLlo world");
+    assert_eq!(s.replacen("l", "L", 2), "heLLo world");
+    assert_eq!(s.replacen("o", "O", 1), "hellO world");
+}
+
+#[test]
+fn test_substring() {
+    let s = CheetahString::from("hello world");
+    assert_eq!(s.substring(0, 5), "hello");
+    assert_eq!(s.substring(6, 11), "world");
+    assert_eq!(s.substring(0, 0), "");
+    assert_eq!(s.substring(5, 5), "");
+}
+
+#[test]
+#[should_panic]
+fn test_substring_invalid_range() {
+    let s = CheetahString::from("hello");
+    let _ = s.substring(0, 10); // Out of bounds
+}
+
+#[test]
+fn test_repeat() {
+    let s = CheetahString::from("abc");
+    assert_eq!(s.repeat(0), "");
+    assert_eq!(s.repeat(1), "abc");
+    assert_eq!(s.repeat(3), "abcabcabc");
+
+    let s2 = CheetahString::from("");
+    assert_eq!(s2.repeat(5), "");
+}
+
+// Add trait tests
+
+#[test]
+fn test_add_str() {
+    let s = CheetahString::from("Hello");
+    let result = s + " World";
+    assert_eq!(result, "Hello World");
+}
+
+#[test]
+fn test_add_cheetah_string() {
+    let s1 = CheetahString::from("Hello");
+    let s2 = CheetahString::from(" World");
+    let result = s1 + &s2;
+    assert_eq!(result, "Hello World");
+}
+
+#[test]
+fn test_add_string() {
+    let s = CheetahString::from("Hello");
+    let result = s + String::from(" World");
+    assert_eq!(result, "Hello World");
+}
+
+#[test]
+fn test_add_assign_str() {
+    let mut s = CheetahString::from("Hello");
+    s += " World";
+    assert_eq!(s, "Hello World");
+}
+
+#[test]
+fn test_add_assign_cheetah_string() {
+    let mut s1 = CheetahString::from("Hello");
+    let s2 = CheetahString::from(" World");
+    s1 += &s2;
+    assert_eq!(s1, "Hello World");
+}
+
+#[test]
+fn test_add_chain() {
+    let s = CheetahString::from("a");
+    let result = s + "b" + "c";
+    assert_eq!(result, "abc");
+}
+
+#[test]
+fn test_add_assign_chain() {
+    let mut s = CheetahString::from("a");
+    s += "b";
+    s += "c";
+    assert_eq!(s, "abc");
+}
+
+#[test]
+fn test_add_empty_strings() {
+    let s1 = CheetahString::from("");
+    let s2 = CheetahString::from("hello");
+    let result = s1 + "hello";
+    assert_eq!(result, s2);
+
+    let s3 = CheetahString::from("hello");
+    let result2 = s3 + "";
+    assert_eq!(result2, "hello");
+}
+
+#[test]
+fn test_add_sso_strings() {
+    // Test SSO strings (<=23 bytes)
+    let s1 = CheetahString::from("short");
+    let result = s1 + " str";
+    assert_eq!(result, "short str");
+    assert_eq!(result.len(), 9);
+}
+
+#[test]
+fn test_add_long_strings() {
+    // Test long strings (>23 bytes)
+    let s1 = CheetahString::from("This is a very long string that exceeds SSO capacity");
+    let result = s1 + " and more";
+    assert_eq!(
+        result,
+        "This is a very long string that exceeds SSO capacity and more"
+    );
+}
+
+// Edge cases and unicode tests
+
+#[test]
+fn test_unicode_queries() {
+    let s = CheetahString::from("你好世界");
+    assert!(s.contains("好"));
+    assert!(s.starts_with("你"));
+    assert!(s.ends_with("界"));
+    assert_eq!(s.find("世"), Some(6));
+}
+
+#[test]
+fn test_unicode_transform() {
+    let s = CheetahString::from("你好");
+    let upper = s.to_uppercase();
+    let lower = s.to_lowercase();
+    // Chinese characters don't change with case
+    assert_eq!(upper, "你好");
+    assert_eq!(lower, "你好");
+}
+
+#[test]
+fn test_unicode_split() {
+    let s = CheetahString::from("你,好,世,界");
+    let parts: Vec<&str> = s.split(",").collect();
+    assert_eq!(parts, vec!["你", "好", "世", "界"]);
+}
+
+#[test]
+fn test_empty_string_operations() {
+    let s = CheetahString::from("");
+    assert_eq!(s.trim(), "");
+    assert_eq!(s.to_uppercase(), "");
+    assert_eq!(s.to_lowercase(), "");
+    assert!(s.starts_with(""));
+    assert!(s.ends_with(""));
+    assert_eq!(s.find(""), Some(0));
+
+    let result = s.clone() + "hello";
+    assert_eq!(result, "hello");
+}
+
+#[test]
+fn test_whitespace_operations() {
+    let s = CheetahString::from("  \t\n  ");
+    assert_eq!(s.trim(), "");
+    assert_eq!(s.len(), 6);
+    assert_eq!(s.trim().len(), 0);
+}


### PR DESCRIPTION

fix #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 16 string query and transformation methods to CheetahString, including `starts_with`, `ends_with`, `contains`, `find`, `trim` variants, `split`, `lines`, `chars`, case conversion, and substring operations.
  * Introduced operator overloading for string concatenation with `Add` and `AddAssign` traits, supporting `&str`, `String`, and `&CheetahString` operands.

* **Tests**
  * Added comprehensive test suite validating string operations, edge cases, and Unicode handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->