### PR TITLE
[ISSUE #86]✨Add character-based methods to CheetahString: starts_with_char, ends_with_char, and contains_char

### DIFF
--- a/examples/char_methods.rs
+++ b/examples/char_methods.rs
@@ -1,0 +1,22 @@
+use cheetah_string::CheetahString;
+
+fn main() {
+    let s = CheetahString::from("hello world");
+
+    // Use starts_with_char method to check characters
+    println!("starts_with_char('h'): {}", s.starts_with_char('h'));
+    println!("starts_with_char('+'): {}", s.starts_with_char('+'));
+
+    // Use ends_with_char method to check characters
+    println!("ends_with_char('d'): {}", s.ends_with_char('d'));
+    println!("ends_with_char('+'): {}", s.ends_with_char('+'));
+
+    // Use contains_char method to check characters
+    println!("contains_char('o'): {}", s.contains_char('o'));
+    println!("contains_char('+'): {}", s.contains_char('+'));
+
+    // Original methods still work with strings
+    println!("starts_with(\"hello\"): {}", s.starts_with("hello"));
+    println!("ends_with(\"world\"): {}", s.ends_with("world"));
+    println!("contains(\"llo\"): {}", s.contains("llo"));
+}

--- a/src/cheetah_string.rs
+++ b/src/cheetah_string.rs
@@ -468,6 +468,22 @@ impl CheetahString {
         self.as_str().starts_with(pat.as_ref())
     }
 
+    /// Returns `true` if the string starts with the given character.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.starts_with_char('h'));
+    /// assert!(!s.starts_with_char('w'));
+    /// ```
+    #[inline]
+    pub fn starts_with_char(&self, pat: char) -> bool {
+        self.as_str().starts_with(pat)
+    }
+
     /// Returns `true` if the string ends with the given pattern.
     ///
     /// # Examples
@@ -484,6 +500,22 @@ impl CheetahString {
         self.as_str().ends_with(pat.as_ref())
     }
 
+    /// Returns `true` if the string ends with the given character.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.ends_with_char('d'));
+    /// assert!(!s.ends_with_char('h'));
+    /// ```
+    #[inline]
+    pub fn ends_with_char(&self, pat: char) -> bool {
+        self.as_str().ends_with(pat)
+    }
+
     /// Returns `true` if the string contains the given pattern.
     ///
     /// # Examples
@@ -498,6 +530,22 @@ impl CheetahString {
     #[inline]
     pub fn contains<P: AsRef<str>>(&self, pat: P) -> bool {
         self.as_str().contains(pat.as_ref())
+    }
+
+    /// Returns `true` if the string contains the given character.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    ///
+    /// let s = CheetahString::from("hello world");
+    /// assert!(s.contains_char('o'));
+    /// assert!(!s.contains_char('x'));
+    /// ```
+    #[inline]
+    pub fn contains_char(&self, pat: char) -> bool {
+        self.as_str().contains(pat)
     }
 
     /// Returns the byte index of the first occurrence of the pattern, or `None` if not found.


### PR DESCRIPTION
fix #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new character-based predicate methods: `starts_with_char()`, `ends_with_char()`, and `contains_char()` for checking strings by individual characters.
  * Added example demonstrating the new character-based predicates alongside existing string-based methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->