### PR TITLE
Feat: Prepare v2.0.0 breaking API cleanup and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release, for example 1.2.0"
+        description: "Version to release, for example 2.0.0"
         required: true
         type: string
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheetah-string"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["mxsm <mxsm@apache.org>"]
 edition = "2021"
 homepage = "https://github.com/mxsm/cheetah-string"

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cheetah-string = "1.2.0"
+cheetah-string = "2.0.0"
 ```
 
 ### Optional Features
 
 ```toml
 [dependencies]
-cheetah-string = { version = "1.2.0", features = ["bytes", "serde", "simd"] }
+cheetah-string = { version = "2.0.0", features = ["bytes", "serde", "simd"] }
 ```
 
 Available features:
@@ -148,7 +148,7 @@ For new code, use:
 | Type | Role |
 |------|------|
 | `CheetahStr` | Immutable clone-cheap values such as topics, groups, names, and keys |
-| `CheetahString` | Mutable string value with the 1.x compatibility API |
+| `CheetahString` | Mutable string value with owned `String` construction semantics |
 | `CheetahBuilder` | Append-heavy construction followed by `finish_string()` or `finish_str()` |
 | `CheetahFinder` | Reusable substring search |
 | `CheetahBytes` | Byte semantics without a UTF-8 promise |
@@ -159,14 +159,21 @@ For new code, use:
 - `new()`, `empty()`, `default()` - Create empty strings
 - `from(s)` - From `&str`, `String`, `&String`, `char`, etc.
 - `from_static_str(s)` - Zero-cost wrapper for `'static str`
-- `from_string(s)` - From owned `String` with the 1.x shared-long-string policy
-- `from_string_owned(s)` - Preserve `String` ownership and spare capacity for mutation
-- `from_string_shared(s)` - Convert long owned strings to clone-cheap shared storage
+- `from_string(s)` - From owned `String`, preserving ownership and spare capacity for mutation
+- `from_string_owned(s)` - Same owned construction policy as `from_string`
+- `from_string_shared(s)` - Convert long owned strings to clone-cheap shared storage; prefer `CheetahStr` for new immutable-key code
 - `try_from_bytes(b)` - Safe construction from bytes with UTF-8 validation
 - `CheetahStr` - Immutable clone-cheap string companion
 - `CheetahBuilder` - Append-heavy builder companion
 - `CheetahBytes` - Byte-oriented companion type available with the `bytes` feature
 - `with_capacity(n)` - Pre-allocate capacity
+
+### 2.0 Migration Notes
+
+- Removed deprecated safe byte constructors: `from_vec`, `from_arc_vec`, and `from_bytes`.
+- Use `try_from_vec`, `try_from_arc_vec`, `try_from_bytes`, or `try_from_bytes_buf` for checked UTF-8 construction.
+- Use `from_utf8_unchecked_vec`, `from_utf8_unchecked_arc_vec`, `from_utf8_unchecked_bytes`, or `from_utf8_unchecked_bytes_buf` only when the caller can prove valid UTF-8.
+- Use `CheetahStr` for immutable clone-cheap keys and `CheetahBuilder` for append-heavy construction.
 
 ### Query Methods
 - `len()`, `is_empty()`, `as_str()`, `as_bytes()`

--- a/bench-results/README.md
+++ b/bench-results/README.md
@@ -30,7 +30,7 @@ Minimum metadata for generated JSON artifacts:
 ```json
 {
   "crate": "cheetah-string",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "profile": "release",
   "target": "x86_64-unknown-linux-gnu",
   "rustc": "rustc 1.xx.x",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cheetah-string"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "memchr",
 ]

--- a/src/cheetah_string.rs
+++ b/src/cheetah_string.rs
@@ -244,16 +244,6 @@ impl CheetahString {
         }
     }
 
-    #[deprecated(
-        since = "1.1.0",
-        note = "use try_from_vec for checked construction or from_utf8_unchecked_vec for an explicit unsafe constructor"
-    )]
-    pub fn from_vec(s: Vec<u8>) -> Self {
-        CheetahString::try_from_vec(s).expect(
-            "CheetahString::from_vec requires valid UTF-8; use try_from_vec for fallible construction",
-        )
-    }
-
     /// Creates a `CheetahString` from a byte vector without validating UTF-8.
     ///
     /// # Safety
@@ -355,17 +345,6 @@ impl CheetahString {
         }
     }
 
-    #[deprecated(
-        since = "1.1.0",
-        note = "use try_from_arc_vec for checked construction or from_utf8_unchecked_arc_vec for an explicit unsafe constructor"
-    )]
-    #[inline]
-    pub fn from_arc_vec(s: Arc<Vec<u8>>) -> Self {
-        CheetahString::try_from_arc_vec(s).expect(
-            "CheetahString::from_arc_vec requires valid UTF-8; use try_from_arc_vec for fallible construction",
-        )
-    }
-
     /// Creates a `CheetahString` from a shared byte vector without validating UTF-8.
     ///
     /// # Safety
@@ -410,7 +389,7 @@ impl CheetahString {
 
     #[inline]
     pub fn from_string(s: String) -> Self {
-        CheetahString::from_string_shared(s)
+        CheetahString::from_string_owned(s)
     }
 
     /// Creates a `CheetahString` from an owned `String` while preserving
@@ -427,9 +406,8 @@ impl CheetahString {
     /// Creates a `CheetahString` from an owned `String` using shared storage
     /// for long immutable strings.
     ///
-    /// This is the same storage policy used by `from_string` in the 1.x line.
-    /// Use `from_string_owned` when spare capacity should be preserved for
-    /// later mutation.
+    /// New code that needs clone-cheap immutable strings should prefer
+    /// `CheetahStr`.
     #[inline]
     pub fn from_string_shared(s: String) -> Self {
         if s.len() <= INLINE_CAPACITY {
@@ -475,18 +453,6 @@ impl CheetahString {
             Ok(s) => CheetahString::from_builder_string(s),
             Err(s) => CheetahString::from_slice(s.as_str()),
         }
-    }
-
-    #[inline]
-    #[cfg(feature = "bytes")]
-    #[deprecated(
-        since = "1.1.0",
-        note = "use try_from_bytes_buf for checked construction or from_utf8_unchecked_bytes_buf for an explicit unsafe constructor"
-    )]
-    pub fn from_bytes(b: bytes::Bytes) -> Self {
-        CheetahString::try_from_bytes_buf(b).expect(
-            "CheetahString::from_bytes requires valid UTF-8; use try_from_bytes_buf for fallible construction",
-        )
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! `CheetahBuilder` is available for append-heavy construction.
 //! The `bytes` feature exposes `CheetahBytes` for byte-oriented data.
 //! It minimizes allocations across small, shared, and builder-oriented string workloads.
-//! The `from_string_owned` and `from_string_shared` constructors make owned
-//! mutation and clone-cheap sharing policies explicit.
+//! `from_string` preserves owned storage for mutable string workflows.
+//! Use `CheetahStr` for clone-cheap immutable values.
 //! Substring search uses `memchr`/`memmem` by default.
 //!
 //! # SIMD Acceleration
@@ -25,7 +25,7 @@
 //! To enable SIMD acceleration:
 //! ```toml
 //! [dependencies]
-//! cheetah-string = { version = "1.2.0", features = ["simd"] }  
+//! cheetah-string = { version = "2.0.0", features = ["simd"] }  
 //! ```
 //!
 //! # Examples

--- a/tests/mutation.rs
+++ b/tests/mutation.rs
@@ -50,6 +50,20 @@ fn from_string_owned_preserves_spare_capacity_for_push() {
 }
 
 #[test]
+fn from_string_defaults_to_owned_policy_in_v2() {
+    let mut raw = String::with_capacity(128);
+    raw.push_str("hello");
+
+    let mut s = CheetahString::from_string(raw);
+    let before = s.as_bytes().as_ptr();
+
+    s.push_str(" world");
+
+    assert_eq!(s, "hello world");
+    assert_eq!(s.as_bytes().as_ptr(), before);
+}
+
+#[test]
 fn from_string_shared_keeps_long_immutable_inputs_clone_cheap() {
     let s = CheetahString::from_string_shared("a".repeat(128));
     let cloned = s.clone();


### PR DESCRIPTION
Closes #128.

Summary:
- Bump crate metadata and docs to v2.0.0.
- Remove deprecated safe byte constructors from CheetahString while keeping checked and explicit unsafe constructors.
- Make CheetahString::from_string use owned mutable storage by default.
- Keep fuzz lock metadata aligned with v2.0.0.

Verification:
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo test --no-default-features
- cargo test --no-default-features --features "serde bytes simd"
- cargo package --allow-dirty
- cargo check --manifest-path fuzz\\Cargo.toml --bins