### PR TITLE
Release v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release, for example 2.0.0"
+        description: "Version to release, for example 2.1.0"
         required: true
         type: string
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheetah-string"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["mxsm <mxsm@apache.org>"]
 edition = "2021"
 homepage = "https://github.com/mxsm/cheetah-string"

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cheetah-string = "2.0.0"
+cheetah-string = "2.1.0"
 ```
 
 ### Optional Features
 
 ```toml
 [dependencies]
-cheetah-string = { version = "2.0.0", features = ["bytes", "serde", "simd"] }
+cheetah-string = { version = "2.1.0", features = ["bytes", "serde", "simd"] }
 ```
 
 Available features:

--- a/bench-results/README.md
+++ b/bench-results/README.md
@@ -39,7 +39,7 @@ Minimum metadata for generated JSON artifacts:
 ```json
 {
   "crate": "cheetah-string",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "profile": "release",
   "target": "x86_64-unknown-linux-gnu",
   "rustc": "rustc 1.xx.x",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cheetah-string"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "memchr",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! To enable SIMD acceleration:
 //! ```toml
 //! [dependencies]
-//! cheetah-string = { version = "2.0.0", features = ["simd"] }  
+//! cheetah-string = { version = "2.1.0", features = ["simd"] }
 //! ```
 //!
 //! # Examples


### PR DESCRIPTION
## Summary

Prepare `cheetah-string` v2.1.0 after the architecture-roadmap improvements merged in #131.

## Changes

- bump crate version from `2.0.0` to `2.1.0`
- update README installation snippets and crate-level feature example
- update benchmark metadata example version
- update release workflow dispatch hint
- update `fuzz/Cargo.lock` path dependency version

## Validation

Local validation passed:

- `cargo fmt --all`
- `cargo check --all-features --all-targets`
- `cargo test --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --no-default-features --features serde,bytes,simd`
- `cargo package` in a clean temporary worktree

## Release

After this PR is merged, trigger `.github/workflows/release.yml` with version `2.1.0`.